### PR TITLE
Fix links to ANSI parser state machine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ If contributing to either `vte` or the `utf8parse` crate and modifying a
 _table.rs.in_ file, make sure to `cargo run` from the _codegen_ folder so that
 the compiled tables are updated.
 
-[Paul Williams' ANSI parser state machine]: http://vt100.net/emu/dec_ansi_parser
+[Paul Williams' ANSI parser state machine]: https://vt100.net/emu/dec_ansi_parser
 [docs]: https://docs.rs/crate/vte/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! [`Parser`]: struct.Parser.html
 //! [`Perform`]: trait.Perform.html
-//! [Paul Williams' ANSI parser state machine]: http://vt100.net/emu/dec_ansi_parser
+//! [Paul Williams' ANSI parser state machine]: https://vt100.net/emu/dec_ansi_parser
 #![no_std]
 
 extern crate utf8parse as utf8;


### PR DESCRIPTION
 http links result in a 404 now, but https links work.