### PR TITLE
Cargo Workspace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ rust:
   - nightly
 
 script:
-  - cargo test
-  - cd utf8parse && cargo test
+  - cargo test --all
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ readme = "README.md"
 [dependencies.utf8parse]
 path = "./utf8parse"
 version = "0.1"
+
+[workspace]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/vte/"
 readme = "README.md"
 
 [dependencies.utf8parse]
-path = "./utf8parse"
+path = "utf8parse"
 version = "0.1"
 
 [workspace]


### PR DESCRIPTION
Not really a big deal, just a tiny little improvement. Since `vte` depends on `utf8parse` inside the same directory tree it's clearly a workspace, and this enables that. Other than `cargo test --all` I'm not really sure of all the advantages of using a workspace here, but still 😜.