### PR TITLE
make osc52 buffer bigger to cover more use cases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ impl State {
 
 
 const MAX_INTERMEDIATES: usize = 2;
-const MAX_OSC_RAW: usize = 1024;
+const MAX_OSC_RAW: usize = 65536;
 const MAX_PARAMS: usize = 16;
 
 struct VtUtf8Receiver<'a, P: Perform + 'a>(&'a mut P, &'a mut State);


### PR DESCRIPTION
This patch is a workaround for issues like https://github.com/jwilm/alacritty/issues/1002 .