### PR TITLE
Fix off-by-one error when parsing CSI escapes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@ impl Parser {
                     // Completed a param
                     let idx = self.num_params;
 
-                    if idx == MAX_PARAMS {
+                    if idx == MAX_PARAMS - 1 {
                         return;
                     }
 
@@ -537,7 +537,7 @@ mod tests {
     fn parse_csi_max_params() {
         use MAX_PARAMS;
 
-        static INPUT: &'static [u8] = b"\x1b[;;;;;;;;;;;;;;;;;p";
+        static INPUT: &'static [u8] = b"\x1b[1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;p";
 
         // Create dispatcher and check state
         let mut dispatcher = CsiDispatcher::default();
@@ -588,6 +588,7 @@ mod tests {
         assert_eq!(dispatcher.params[0], &[i64::MAX as i64]);
 
     }
+
     #[test]
     fn parse_osc_with_utf8_arguments() {
         static INPUT: &'static [u8] = &[


### PR DESCRIPTION
The CSI escape sequences are limited to 16 parameters using the
`MAX_PARAMS` constant.

To make sure no more params are parsed, the CSI parser stops when the
parameter index reaches `MAX_PARAMS`, however this means that it stops
at index 16, which means that the number of params would be 17 since
arrays start at 0.

To fix this off-by-one error the CSI parser now stops when the index
reaches `MAX_PARAMS - 1`, which means it will stop when the index
reaches the last element in an array with `MAX_PARAMS` number of
elements.

This fixes jwilm/alacritty#1505.