### PR TITLE
Use dynamically sized buffer for OSC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ rust:
 
 script:
   - cargo test --all
+  - cargo test --all --no-default-features
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ rust:
 
 script:
   - cargo test --all
-  - cargo test --all --no-default-features
+  - cargo test --all --features nostd
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ path = "utf8parse"
 version = "0.1"
 
 [features]
-default = ["std"]
-std = []
+default = []
+nostd = []
 
 [workspace]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vte"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0 OR MIT"
 description = "Parser for implementing terminal emulators"
@@ -12,6 +12,10 @@ readme = "README.md"
 [dependencies.utf8parse]
 path = "utf8parse"
 version = "0.1"
+
+[features]
+default = ["std"]
+std = []
 
 [workspace]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ mod oscbuf {
         pub fn new(size_limit: usize) -> Self {
             Self {
                 buf: Vec::with_capacity(MAX_OSC_RAW.min(size_limit)),
-                    size_limit,
+                size_limit,
             }
         }
 


### PR DESCRIPTION
Whilst playing around with vte and processing iTerm2's image protocol,
I ran into the relatively small statically sized OSC buffer.

This diff switches the buffer from a static array to use a `Vec<u8>`.  I
did briefly experiment with just making this buffer much larger (as
https://github.com/jwilm/vte/pull/15 does), but even at 1MB (which is
too small for images) that size can lead to a stack overflow during
initialization.

In order to preserve building in a `no_std` environment this is done
conditionally.  I've followed the pattern used in other crates with
similar requirements:

* Introduced a `std` feature to signal that `std` is ok
* The `std` feature is on by default
* `no_std` crates that consume this one will need to set `vte` to
  `default-features = false` in their deps
* I've bumped the version in order to avoid breaking `no_std`
  consumers

Test Plan:

```
$ cargo test --no-default-features
$ cargo test
```

Refs: https://github.com/jwilm/alacritty/issues/1002