### PR TITLE
fix dcs handling, and add a test for it

### DIFF
--- a/examples/parselog.rs
+++ b/examples/parselog.rs
@@ -15,9 +15,9 @@ impl vte::Perform for Log {
         println!("[execute] {:02x}", byte);
     }
 
-    fn hook(&mut self, params: &[i64], intermediates: &[u8], ignore: bool) {
-        println!("[hook] params={:?}, intermediates={:?}, ignore={:?}",
-                 params, intermediates, ignore);
+    fn hook(&mut self, params: &[i64], intermediates: &[u8], ignore: bool, c: char) {
+        println!("[hook] params={:?}, intermediates={:?}, ignore={:?}, char={:?}",
+                 params, intermediates, ignore, c);
     }
 
     fn put(&mut self, byte: u8) {


### PR DESCRIPTION
fixes https://github.com/jwilm/vte/issues/28.

it turns out that there were a couple different issues with dcs parsing, and this should resolve all of them:

* the final character of the dcs introducer was not being passed to the `hook` method, making it impossible to determine which dcs sequence was being processed (which is necessary to correctly handle the `put` method)
* the last parameter was being incorrectly dropped

the test tests the dcs sequence `DECUDK` documented in the xterm documentation.

additionally, you can see the difference in the `parselog` output before this change:

```
$ perl -E'print "foo\eP0;1|17/ab\x9cbar"' | cargo run -q --example parselog
[print] 'f'
[print] 'o'
[print] 'o'
[hook] params=[0], intermediates=[], ignore=false
[put] 31
[put] 37
[put] 2f
[put] 61
[put] 62
[unhook]
[print] 'b'
[print] 'a'
[print] 'r'
```

compared to after:

```
$ perl -E'print "foo\eP0;1|17/ab\x9cbar"' | cargo run -q --example parselog
[print] 'f'
[print] 'o'
[print] 'o'
[hook] params=[0, 1], intermediates=[], ignore=false, char='|'
[put] 31
[put] 37
[put] 2f
[put] 61
[put] 62
[unhook]
[print] 'b'
[print] 'a'
[print] 'r'
```